### PR TITLE
Added missing tag for android 12

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <permission android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION"
         android:protectionLevel="signature" />
     <application>
-        <service android:name="ly.count.dart.countly_flutter.CountlyMessagingService">
+        <service android:name="ly.count.dart.countly_flutter.CountlyMessagingService" android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>


### PR DESCRIPTION
Android 12 required to use android:exported="true|false" for all services, activities ... Without this can't install on the device with android 12 os