### PR TITLE
add exported true on manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,12 +5,16 @@
     <permission android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION"
         android:protectionLevel="signature" />
     <application>
-        <service android:name="ly.count.dart.countly_flutter.CountlyMessagingService">
+        <service
+            android:name="ly.count.dart.countly_flutter.CountlyMessagingService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
-        <receiver android:name="ly.count.android.sdk.ReferrerReceiver" android:exported="true">
+        <receiver
+            android:name="ly.count.android.sdk.ReferrerReceiver"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>


### PR DESCRIPTION
[Targeting S+ (version 31 and above) requires that an explicit value for android: exported be defined when intent filters are present]](https://stackoverflow.com/questions/70333565/targeting-s-version-31-and-above-requires-that-an-explicit-value-for-android)

getting this error while running the application on Android 12 device. 