### PR TITLE
Fix: Non fatal crashes are handled as fatal crashes in Android

### DIFF
--- a/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java
+++ b/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java
@@ -390,16 +390,16 @@ public class CountlyFlutterPlugin implements MethodCallHandler, FlutterPlugin, A
                 result.success("addCrashLog success!");
             } else if ("logException".equals(call.method)) {
                 String exceptionString = args.getString(0);
-                boolean fatal = args.getBoolean(1);
+                boolean nonFatal = args.getBoolean(1);
                 Exception exception = new Exception(exceptionString);
                 Map<String, Object> segments = new HashMap<>();
                 for (int i = 2, il = args.length(); i < il; i += 2) {
                     segments.put(args.getString(i), args.getString(i + 1));
                 }
-                if (fatal) {
-                    Countly.sharedInstance().crashes().recordUnhandledException(exception, segments);
-                } else {
+                if (nonFatal) {
                     Countly.sharedInstance().crashes().recordHandledException(exception, segments);
+                } else {
+                    Countly.sharedInstance().crashes().recordUnhandledException(exception, segments);
                 }
 
                 result.success("logException success!");


### PR DESCRIPTION
Currently, nonFatal exceptions are not correctly handled in the Android implementation of the plugin.

This is the Flutter-Code to report exceptions:
```dart
static Future<String?> logException(String exception, bool nonfatal, [Map<String, Object>? segmentation]) async {
    if (!_instance._countlyState.isInitialized) {
      String message = '"initWithConfig" must be called before "logException"';
      log('logException, $message', logLevel: LogLevel.ERROR);
      return message;
    }
    int segCount = segmentation != null ? segmentation.length : 0;
    log('Calling "logException":[$exception] nonfatal:[$nonfatal]: with segmentation count:[$segCount]');
    List<String> args = [];
    args.add(exception);
    args.add(nonfatal.toString());
    if (segmentation != null) {
      segmentation.forEach((k, v) {
        args.add(k.toString());
        args.add(v.toString());
      });
    }
    final String? result = await _channel.invokeMethod('logException', <String, dynamic>{'data': json.encode(args)});

    return result;
  }
```
The flag to mark an exception as fatal/nonfatal is called "nonfatal". So if the exception is fatal it is "false" and "true" if the exception is fatal.

The corresponding code in the Android-Plugin looks like this:

```java
else if ("logException".equals(call.method)) {
                String exceptionString = args.getString(0);
                boolean fatal = args.getBoolean(1);
                Exception exception = new Exception(exceptionString);
                Map<String, Object> segments = new HashMap<>();
                for (int i = 2, il = args.length(); i < il; i += 2) {
                    segments.put(args.getString(i), args.getString(i + 1));
                }
                if (fatal) {
                    Countly.sharedInstance().crashes().recordUnhandledException(exception, segments);
                } else {
                    Countly.sharedInstance().crashes().recordHandledException(exception, segments);
                }

                result.success("logException success!");
            }
```

Here it takes the "nonfatal" as "fatal". This results in that the flag "fatal" is used in the wrong way.
If in Flutter the Flag is nonfatal = true it will result in fatal = true in Android or the other way round (nonfatal = false => fatal false).

I decided to change it in the platform code to not introduce a breaking change.