### PR TITLE
single line stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## x.x.x
+* Addressed an issue that prevented the stacktrace from being properly recognized on the server
+
+* Underlying Android SDK version is 24.7.1
+* Underlying iOS SDK version is 24.7.1
+
 ## 24.7.1
 * Added a new configuration option `enableTemporaryDeviceIDMode` to 'CountlyConfig' interface
 * Introduced a new `deviceID` interface for grouping device ID management related methods:

--- a/lib/src/countly_flutter.dart
+++ b/lib/src/countly_flutter.dart
@@ -1871,7 +1871,7 @@ class Countly {
     String exceptionString = exception.toString();
     log('Calling "logExceptionEx":[$exceptionString] nonfatal:[$nonfatal]');
     stacktrace ??= StackTrace.current;
-    final result = logException('$exceptionString\n\n$stacktrace', nonfatal, segmentation);
+    final result = logException('$exceptionString\n$stacktrace', nonfatal, segmentation);
     return result;
   }
 
@@ -1888,7 +1888,7 @@ class Countly {
   static Future<String?> logExceptionManual(String message, bool nonfatal, {StackTrace? stacktrace, Map<String, Object>? segmentation}) async {
     log('Calling "logExceptionManual":[$message] nonfatal:[$nonfatal]');
     stacktrace ??= StackTrace.current;
-    final result = logException('$message\n\n$stacktrace', nonfatal, segmentation);
+    final result = logException('$message\n$stacktrace', nonfatal, segmentation);
     return result;
   }
 
@@ -1941,7 +1941,7 @@ class Countly {
 
     stack ??= StackTrace.fromString('');
     try {
-      unawaited(logException('${exception.toString()}\n\n$stack', true));
+      unawaited(logException('${exception.toString()}\n$stack', true));
     } catch (e) {
       log('_internalRecordError, Sending crash report to Countly failed: $e');
     }


### PR DESCRIPTION
This PR resolves an issue where the stack trace on the server was not properly recognized due to double newlines. The fix standardizes it to a single newline for correct processing.