### PR TITLE
Add namespace to SDK build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'ly.count.dart.countly_flutter'
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'ly.count.dart.countly_flutter'
+    }
     compileSdk 33
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'ly.count.dart.countly_flutter'
     compileSdk 33
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ly.count.dart.countly_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="${applicationId}.CountlyPush.BROADCAST_PERMISSION" />


### PR DESCRIPTION
This PR is related to a client's request on Discord (https://discord.com/channels/1088398296789299280/1088720318425743451/threads/1276102278180376597). He is having problems because there is no namespace on our `android/build.gradle` file.

This code has been manually tested.