### PR TITLE
bugfix: remove registerWith function (Not supported in Flutter 3.29.0)

### DIFF
--- a/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java
+++ b/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java
@@ -9,7 +9,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import ly.count.android.sdk.Countly;
 import ly.count.android.sdk.CountlyConfig;
@@ -139,15 +138,6 @@ public class CountlyFlutterPlugin implements MethodCallHandler, FlutterPlugin, A
     List<CountlyFeedbackWidget> retrievedWidgetList = null;
 
     //----------PLUGIN REGISTRATION (FlutterPlugin)-------------------
-    
-    // Required for pre Flutter 1.12 projects
-    public static void registerWith(Registrar registrar) {
-        final CountlyFlutterPlugin instance = new CountlyFlutterPlugin();
-        instance.activity = registrar.activity();
-        final Context __context = registrar.context();
-        instance.onAttachedToEngineInternal(__context, registrar.messenger());
-        log("registerWith", LogLevel.INFO);
-    }
 
     // Called from Android embedding v2
     @Override


### PR DESCRIPTION
The registerWith function is not supported anymore starting with Flutter 3.29.0.

This is the old documentation about the deprecation. It seems like it finally got removed with Flutter 3.29.0.
(https://docs.flutter.dev/release/breaking-changes/plugin-api-migration)
> Also, note that the plugin should still contain the static registerWith() method to remain compatible with apps that don't use the v2 Android embedding. (See [Upgrading pre 1.12 Android projects](https://github.com/flutter/flutter/blob/main/docs/platforms/android/Upgrading-pre-1.12-Android-projects.md) for details.) The easiest thing to do (if possible) is move the logic from registerWith() into a private method that both registerWith() and onAttachedToEngine() can call. Either registerWith() or onAttachedToEngine() will be called, not both.

I did not find the information in the official release notes, but if you try to compile the plugin with the latest Flutter version you will encounter this issue:
```
.pub-cache/hosted/pub.dev/countly_flutter-25.1.0/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java:12: error: cannot find symbol
import io.flutter.plugin.common.PluginRegistry.Registrar;
                                              ^
  symbol:   class Registrar
  location: interface PluginRegistry
.pub-cache/hosted/pub.dev/countly_flutter-25.1.0/android/src/main/java/ly/count/dart/countly_flutter/CountlyFlutterPlugin.java:144: error: cannot find symbol
```

The solution was already implemented in other plugins as well. E.g: https://github.com/acoutts/flutter_libphonenumber/pull/93